### PR TITLE
fix: get tests to run

### DIFF
--- a/deploy/001_deploy_market_factory.ts
+++ b/deploy/001_deploy_market_factory.ts
@@ -1,5 +1,6 @@
 import {HardhatRuntimeEnvironment} from 'hardhat/types';
 import {DeployFunction} from 'hardhat-deploy/types';
+import { ethers } from 'hardhat';
 
 const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   const {deployments, getNamedAccounts} = hre;
@@ -11,6 +12,7 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
     from: deployer,
     args: [],
     log: true,
+    gasPrice: ethers.BigNumber.from('0'),
     gasLimit: 8999999,
   });
   deployments.log(

--- a/deploy/002_deploy_amm.ts
+++ b/deploy/002_deploy_amm.ts
@@ -4,6 +4,7 @@ import {
   abi as FACTORY_ABI,
   bytecode as FACTORY_BYTECODE,
 } from '@uniswap/v3-core/artifacts/contracts/UniswapV3Factory.sol/UniswapV3Factory.json';
+import { ethers } from 'hardhat';
 
 /* OPTIMISM
 import {
@@ -21,6 +22,8 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
     from: deployer,
     args: [],
     log: true,
+    gasPrice: ethers.BigNumber.from('0'), 
+    gasLimit: 8999999, 
     contract: {
       abi: FACTORY_ABI,
       bytecode: FACTORY_BYTECODE,

--- a/deploy/003_deploy_amm_router.ts
+++ b/deploy/003_deploy_amm_router.ts
@@ -12,6 +12,7 @@ import {
   abi as SWAP_ROUTER_ABI,
   bytecode as SWAP_ROUTER_BYTECODE,
 } from '@uniswap/v3-periphery/artifacts/contracts/SwapRouter.sol/SwapRouter.json';
+import { ethers } from 'hardhat';
 
 const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   const {deployments, getNamedAccounts} = hre;
@@ -24,6 +25,8 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
     from: deployer,
     args: [factory.address, weth],
     log: true,
+    gasPrice: ethers.BigNumber.from('0'),
+    gasLimit: 8999999,
     contract: {
       abi: SWAP_ROUTER_ABI,
       bytecode: SWAP_ROUTER_BYTECODE,

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -58,7 +58,7 @@ const config: HardhatUserConfig = {
         : undefined,
     },
     optimism: {
-      url: 'http://127.0.0.1:8545',
+      url: 'https://goerli.optimism.io/',
       accounts: accounts(),
       gasPrice: 0,
       blockGasLimit: 8999999,

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -1,5 +1,5 @@
 import 'dotenv/config';
-import {HardhatUserConfig} from 'hardhat/types';
+import { HardhatUserConfig } from 'hardhat/types';
 import 'hardhat-deploy';
 import 'hardhat-deploy-ethers';
 import 'hardhat-gas-reporter';
@@ -8,8 +8,8 @@ import 'hardhat-typechain';
 import 'solidity-coverage';
 import '@eth-optimism/hardhat-ovm';
 
-import {accounts, keys, node_url} from './utils/network';
-import {utils} from 'ethers';
+import { accounts, keys, node_url } from './utils/network';
+import { utils } from 'ethers';
 
 const config: HardhatUserConfig = {
   solidity: {
@@ -50,15 +50,15 @@ const config: HardhatUserConfig = {
       accounts: accounts(process.env.HARDHAT_FORK),
       forking: process.env.HARDHAT_FORK
         ? {
-            url: node_url(process.env.HARDHAT_FORK),
-            blockNumber: process.env.HARDHAT_FORK_NUMBER
-              ? parseInt(process.env.HARDHAT_FORK_NUMBER)
-              : undefined,
-          }
+          url: node_url(process.env.HARDHAT_FORK),
+          blockNumber: process.env.HARDHAT_FORK_NUMBER
+            ? parseInt(process.env.HARDHAT_FORK_NUMBER)
+            : undefined,
+        }
         : undefined,
     },
     optimism: {
-      url: 'https://goerli.optimism.io/',
+      url: 'http://127.0.0.1:8545',
       accounts: accounts(),
       gasPrice: 0,
       blockGasLimit: 8999999,
@@ -131,10 +131,10 @@ const config: HardhatUserConfig = {
   },
   external: process.env.HARDHAT_FORK
     ? {
-        deployments: {
-          hardhat: ['deployments/' + process.env.HARDHAT_FORK],
-        },
-      }
+      deployments: {
+        hardhat: ['deployments/' + process.env.HARDHAT_FORK],
+      },
+    }
     : undefined,
 };
 export default config;

--- a/test/MarketFactory.test.ts
+++ b/test/MarketFactory.test.ts
@@ -1,21 +1,23 @@
-import {expect} from './chai-setup';
+import { expect } from './chai-setup';
 import {
   deployments,
   ethers,
   getNamedAccounts,
   getUnnamedAccounts,
 } from 'hardhat';
-import {DummyERC20, MarketFactory} from '../typechain';
-import {setupUser, setupUsers} from './utils';
+import { DummyERC20, MarketFactory } from '../typechain';
+import { setupUser, setupUsers } from './utils';
 
 const setup = deployments.createFixture(async () => {
   await deployments.fixture('MarketFactory');
-  const {deployer} = await getNamedAccounts();
+  const { deployer } = await getNamedAccounts();
 
   await deployments.deploy('DummyERC20', {
     from: deployer,
     args: [],
     log: true,
+    gasPrice: ethers.BigNumber.from('0'),
+    gasLimit: 8999999
   });
   const contracts = {
     MarketFactory: <MarketFactory>await ethers.getContract('MarketFactory'),
@@ -32,7 +34,7 @@ describe('Market Factory', function () {
   const IPFS = 'QmWWQSuPMS6aXCbZKpEjPHPUZN2NjB3YrhJTHsV4X3vb2t';
 
   it('Successfully create market', async function () {
-    const {deployer} = await setup();
+    const { deployer } = await setup();
     const resolution = Math.round(new Date().getTime() / 1000) + 10000;
 
     await expect(
@@ -42,13 +44,16 @@ describe('Market Factory', function () {
         deployer.address,
         deployer.address,
         resolution,
-        deployer.USDC.address
+        deployer.USDC.address,
+        {
+          gasPrice: ethers.BigNumber.from('0'), gasLimit: 8999999
+        }
       )
     ).to.emit(deployer.MarketFactory, 'Deployed');
   });
 
   it('Fail at creating a Market w/ one outcome', async function () {
-    const {deployer} = await setup();
+    const { deployer } = await setup();
     const resolution = Math.round(new Date().getTime() / 1000) + 10000;
 
     await expect(
@@ -58,7 +63,10 @@ describe('Market Factory', function () {
         deployer.address,
         deployer.address,
         resolution,
-        deployer.USDC.address
+        deployer.USDC.address,
+        {
+          gasPrice: ethers.BigNumber.from('0'), gasLimit: 8999999
+        }
       )
     ).to.be.reverted;
   });


### PR DESCRIPTION
Things I did:
1. Added `optimism` monorepo to start docker services:
    2. Do this by:
        3. Cloning the `optimism` repo
        4. Install and build deps: `yarn && yarn build`
        5. Build and run docker services within `optimism/ops` directory: `docker-compose build && docker-compose up`
2. Started the docker services
3. Ran tests
4. Corrected contract calls to use `gasPrice: ethers.BigNumber.from('0')` and `gasLimit: 8999999`

## UPDATE
Restarted the local docker containers and was able to see the tests pass